### PR TITLE
CMake: Only install to DEVKITPRO if there's no INSTALL_PREFIX set

### DIFF
--- a/libseven/CMakeLists.txt
+++ b/libseven/CMakeLists.txt
@@ -6,6 +6,12 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    # Default to MinSizeRel build type
+    set(CMAKE_BUILD_TYPE "MinSizeRel" CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 project(libseven C ASM)
 set(CMAKE_INCLUDE_FLAG_ASM "-Wa,-I")
 
@@ -17,6 +23,7 @@ add_library(seven STATIC
     src/hw/isr.s
     src/hw/sram.s
     src/hw/timer.s
+
     src/util/assert.c
     src/util/bit.s
     src/util/debug.s
@@ -26,6 +33,7 @@ add_library(seven STATIC
     src/util/rand.s
     src/util/simd.s
     src/util/str.s
+
     src/video/oam.s
 )
 
@@ -43,4 +51,7 @@ if(EXISTS $ENV{DEVKITPRO})
     file(TO_CMAKE_PATH "$ENV{DEVKITPRO}" ENV_DEVKITPRO)
     install(TARGETS seven DESTINATION "${ENV_DEVKITPRO}/libseven/lib")
     install(DIRECTORY include/ DESTINATION "${ENV_DEVKITPRO}/libseven/include")
+else()
+    install(TARGETS seven LIBRARY DESTINATION lib)
+    install(DIRECTORY include/ DESTINATION include)
 endif()

--- a/libseven/CMakeLists.txt
+++ b/libseven/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(seven STATIC
     src/hw/isr.s
     src/hw/sram.s
     src/hw/timer.s
-
     src/util/assert.c
     src/util/bit.s
     src/util/debug.s
@@ -33,7 +32,6 @@ add_library(seven STATIC
     src/util/rand.s
     src/util/simd.s
     src/util/str.s
-
     src/video/oam.s
 )
 
@@ -47,7 +45,7 @@ target_compile_options(seven PRIVATE
 # Allow the string "libseven" as a parameter for target_link_libraries
 add_library(libseven ALIAS seven)
 
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND EXISTS $ENV{DEVKITPRO})
     file(TO_CMAKE_PATH "$ENV{DEVKITPRO}" ENV_DEVKITPRO)
     set(CMAKE_INSTALL_PREFIX "${ENV_DEVKITPRO}/libseven" CACHE PATH "..." FORCE)
 endif()

--- a/libseven/CMakeLists.txt
+++ b/libseven/CMakeLists.txt
@@ -47,11 +47,10 @@ target_compile_options(seven PRIVATE
 # Allow the string "libseven" as a parameter for target_link_libraries
 add_library(libseven ALIAS seven)
 
-if(EXISTS $ENV{DEVKITPRO})
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     file(TO_CMAKE_PATH "$ENV{DEVKITPRO}" ENV_DEVKITPRO)
-    install(TARGETS seven DESTINATION "${ENV_DEVKITPRO}/libseven/lib")
-    install(DIRECTORY include/ DESTINATION "${ENV_DEVKITPRO}/libseven/include")
-else()
-    install(TARGETS seven LIBRARY DESTINATION lib)
-    install(DIRECTORY include/ DESTINATION include)
+    set(CMAKE_INSTALL_PREFIX "${ENV_DEVKITPRO}/libseven" CACHE PATH "..." FORCE)
 endif()
+
+install(TARGETS seven LIBRARY DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)


### PR DESCRIPTION
Also defaults to `MinSizeRel` if there's no build type set