### PR TITLE
gbafix: fix argument handling for string options

### DIFF
--- a/tools/src/gbafix.py
+++ b/tools/src/gbafix.py
@@ -84,9 +84,9 @@ def main():
 
     p.add_argument("file", help="ROM file to fix", type=argparse.FileType("r+b"))
     p.add_argument("-t", "--title", type=str, nargs="?", const="", dest="title")
-    p.add_argument("-c", "--code", type=str, nargs=1, dest="game_code")
-    p.add_argument("-m", "--maker", type=str, nargs=1, dest="maker_code")
-    p.add_argument("-r", "--revision", type=int, nargs=1, dest="version")
+    p.add_argument("-c", "--code", type=str, dest="game_code")
+    p.add_argument("-m", "--maker", type=str, dest="maker_code")
+    p.add_argument("-r", "--revision", type=int, dest="version")
     p.add_argument("-p", "--pad", type=int, nargs="?", dest="pad")
     p.add_argument("-d", "--debug", type=int, nargs="?", dest="debug")
 
@@ -101,9 +101,9 @@ def main():
 
     opts.title = path.basename(opts.file.name) if opts.title == "" else opts.title
 
-    header.title        = opts.title or header.title
-    header.game_code    = opts.game_code or header.game_code
-    header.maker_code   = opts.maker_code or header.maker_code
+    header.title        = opts.title.encode("ascii") if opts.title else header.title
+    header.game_code    = opts.game_code.encode("ascii") if opts.game_code else header.game_code
+    header.maker_code   = opts.maker_code.encode("ascii") if opts.maker_code else header.maker_code
     header.version      = opts.version or header.version
 
     binh = header.to_bytes()


### PR DESCRIPTION
Just a quick patch to fix the following error I got when trying to pass `--title`, `--code`, or `--maker`:
```
argument for 's' must be a bytes object
```

Tested under Python 3.10.12 and 3.11.4. If there's an older minimum version you still want supported that these changes might be incompatible with, please let me know and I'll test them on that version too.

<details><summary>Detailed rationale:</summary>

- Specifying `nargs`; even `nargs=1` in `ArgumentParser.add_argument` returns a list of type, removing it seems easier as the behaviour for duplicate arguments is the same either way.
- `struct.unpack`'s `s` format chokes on non-bytes types, so I had to use `str.encode("ascii")`. The or assignments seemed like the best place to do this as the extracted header fields are already bytes objects, let me know if the ternaries are fine or if proper if statements would be preferable here.
</details>